### PR TITLE
improvement: adicionando o StringComparison.OrdinalIgnoreCase nos métodos ContemCaractere() e TextoTerminaCom()

### DIFF
--- a/desafios-projetos-wex/TestesUnitarios.Desafio.Console/Services/ValidacoesString.cs
+++ b/desafios-projetos-wex/TestesUnitarios.Desafio.Console/Services/ValidacoesString.cs
@@ -10,13 +10,13 @@ namespace TestesUnitarios.Desafio.Console.Services
 
         public bool ContemCaractere(string texto, string textoProcurado)
         {
-            var contem = texto.Contains(textoProcurado);
+            var contem = texto.Contains(textoProcurado, StringComparison.OrdinalIgnoreCase);
             return contem;
         }
 
         public bool TextoTerminaCom(string texto, string textoProcurado)
         {
-            var termina = texto.EndsWith(textoProcurado);
+            var termina = texto.EndsWith(textoProcurado, StringComparison.OrdinalIgnoreCase);
             return termina;
         }
     }


### PR DESCRIPTION
Os métodos ContemCaractere() e TextoTerminaCom() não levava em consideração o tratamento dos cases das strings causando falso negativo.