### PR TITLE
fix: Corrigir a variável "texto" e "resultadoEsperado" da seção Arrange;

### DIFF
--- a/desafios-projetos-wex/TestesUnitarios.Desafio.Tests/ValidacoesStringTests.cs
+++ b/desafios-projetos-wex/TestesUnitarios.Desafio.Tests/ValidacoesStringTests.cs
@@ -9,11 +9,9 @@ public class ValidacoesStringTests
     [Fact]
     public void DeveRetornar6QuantidadeCaracteresDaPalavraMatrix()
     {
-        //TODO: Corrigir a variável "texto" e "resultadoEsperado" da seção Arrange
-
         // Arrange
-        var texto = "a";
-        var resultadoEsperado = 0;
+        var texto = "Matrix";
+        var resultadoEsperado = 6;
 
         // Act
         var resultado = _validacoes.RetornarQuantidadeCaracteres(texto);
@@ -26,16 +24,14 @@ public class ValidacoesStringTests
     public void DeveContemAPalavraQualquerNoTexto()
     {
         // Arrange
-        var texto = "Esse é um texto qualquer";
-        var textoProcurado = "qualquer";
+        var texto = "Esse é um texto QUALQUER";
+        var textoProcurado = "Qualquer";
 
-        //TODO: Corrigir a chamada do método "ContemCaractere" da seção Act
         // Act
-         _validacoes.ContemCaractere(texto, textoProcurado);
+         bool resultado = _validacoes.ContemCaractere(texto, textoProcurado);
 
         // Assert
-        //TODO: Corrigir o Assert.True com base no retorno da chamada ao método
-        Assert.True(true);
+        Assert.True(resultado);
     }
 
     [Fact]
@@ -49,18 +45,16 @@ public class ValidacoesStringTests
         var resultado = _validacoes.ContemCaractere(texto, textoProcurado);
 
         // Assert
-        //TODO: Corrigir o Assert.False com base no retorno da chamada ao método
-        Assert.False(true);
+        Assert.False(resultado);
     }
 
-    //TODO: Corrigir a anotação [Fact]
+    [Fact]
     public void TextoDeveTerminarComAPalavraProcurado()
     {
-        //TODO: Corrigir a variável "textoProcurado" seção Arrange
 
         // Arrange
         var texto = "Começo, meio e fim do texto procurado";
-        var textoProcurado = "teste";
+        var textoProcurado = "procurado";
 
         // Act
         var resultado = _validacoes.TextoTerminaCom(texto, textoProcurado);


### PR DESCRIPTION
fix: Corrigir a chamada do método "ContemCaractere" da seção Act;

fix: Corrigir o Assert.True com base no retorno da chamada ao método;

fix: Corrigir o Assert.False com base no retorno da chamada ao método;

fix: Corrigir a anotação [Fact] TestesUnitarios.Desafio.Tests;

fix: Corrigir a variável "textoProcurado" seção Arrange TestesUnitarios.Desafio.Tests;